### PR TITLE
fixing warnings

### DIFF
--- a/main.c
+++ b/main.c
@@ -3,7 +3,7 @@
 #include <IOKit/graphics/IOGraphicsLib.h>
 #include <ApplicationServices/ApplicationServices.h>
 
-const int         kMaxDisplays       = 16;
+#define kMaxDisplays 16
 const CFStringRef kDisplayBrightness = CFSTR(kIODisplayBrightnessKey);
 const char*       APP_NAME;
 

--- a/main.c
+++ b/main.c
@@ -140,6 +140,7 @@ int main(int argc, char * const argv[]) {
       }
     }
 
+    /* CGDisplayIOServicePort - Deprecated in OS X v10.9. There is no replacement. */
     io_service_t service = CGDisplayIOServicePort(dspy);
 
     switch (action) {


### PR DESCRIPTION
I got these warnings with such flags CFLAGS = -pedantic -Wall -Wextra:

```
clang  -pedantic -Wall -Wextra  main.c -c -o main.o
main.c:100:29: warning: variable length array folded to constant array as an
      extension [-Wpedantic]
  CGDirectDisplayID display[kMaxDisplays];
                            ^~~~~~~~~~~~
main.c:124:38: warning: 'CGDisplayCurrentMode' is deprecated: first deprecated
      in OS X 10.6 [-Wdeprecated-declarations]
    CFDictionaryRef   originalMode = CGDisplayCurrentMode(dspy);
                                     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/CoreGraphics.framework/Headers/CGDirectDisplay.h:455:27: note: 
      'CGDisplayCurrentMode' declared here
CG_EXTERN CFDictionaryRef CGDisplayCurrentMode(CGDirectDisplayID display)
                          ^
main.c:143:28: warning: 'CGDisplayIOServicePort' is deprecated: first deprecated
      in OS X 10.9 [-Wdeprecated-declarations]
    io_service_t service = CGDisplayIOServicePort(dspy);
                           ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/CoreGraphics.framework/Headers/CGDisplayConfiguration.h:355:24: note: 
      'CGDisplayIOServicePort' declared here
CG_EXTERN io_service_t CGDisplayIOServicePort(CGDirectDisplayID display)
                       ^
main.c:180:2: warning: no newline at end of file [-Wnewline-eof]
}
 ^
4 warnings generated.
```
